### PR TITLE
fix: Prioritize end_call tool detection over transport hangup reason

### DIFF
--- a/src/eva/assistant/telephony_bridge.py
+++ b/src/eva/assistant/telephony_bridge.py
@@ -512,16 +512,18 @@ class TelephonyBridgeServer:
         return time.time()
 
     def _infer_session_end_reason(self) -> str | None:
-        if self._session_end_reason:
-            return self._session_end_reason
-
-        # Check for end_call tool invocation.
+        # Check for end_call tool invocation first — if the assistant
+        # called end_call, the session ended with a proper goodbye
+        # regardless of whether the transport reported "assistant_hangup".
         for entry in reversed(self.audit_log.transcript):
             if entry.get("message_type") not in {"tool_call", "tool_response"}:
                 continue
             value = entry.get("value", {})
             if isinstance(value, dict) and value.get("tool") == "end_call":
                 return "goodbye"
+
+        if self._session_end_reason:
+            return self._session_end_reason
 
         return None
 


### PR DESCRIPTION
When the assistant calls end_call, the session ended with a proper goodbye — even though the transport reports 'assistant_hangup'. Check the audit log for end_call first before falling back to the transport-level session end reason.

This fixes conversation_finished validation which expects reason='goodbye' in elevenlabs_events.jsonl. Without this, all telephony bridge calls that end via end_call webhook fail validation because the bridge VAD observer records 'assistant_hangup' instead of 'goodbye'.

904 tests pass.